### PR TITLE
Bug fix for Issue #62 Euclidian crashing

### DIFF
--- a/src/Euclidian.cpp
+++ b/src/Euclidian.cpp
@@ -203,7 +203,7 @@ struct Euclidian : Module {
             }
         }
 
-        if(head<16){
+        if((head<16)&&(head>=0)){
             if(final_string[head] == "1"[0]){
                 lights[PATTERN_LIGHT + head].setBrightness(1.0f);
             } else{


### PR DESCRIPTION
By the time you get to line 206, head might have been reset to -1

If you are in a frame where the clock input has not been triggered, then head will not have been advanced. As a result you are overwriting the memory before the first light object, which is probably why the crash logs were fingering the DestroyLight methods