### PR TITLE
Fix Widener crash on Windows due to use of std::random_device

### DIFF
--- a/src/Widener.cpp
+++ b/src/Widener.cpp
@@ -43,8 +43,6 @@ struct Widener : Module {
     float mixed = 0.0;
     float mix_value = 1.0;
 
-    std::random_device rd; // obtain a random number from hardware
-
     float outLP;
     float outHP;
 


### PR DESCRIPTION
Same issue I found here bogaudio/BogaudioModules#132
This line can be removed as it's unused anyway. Doing so and the module loads fine.